### PR TITLE
Update example to use reverse port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ https://assetstore.unity.com/packages/essentials/tutorial-projects/endless-runne
 ### Before running the tests on iOS
 - in the `run-tests-ios.sh` script please change the value for `APPIUM_XCODEORGID` with your Team ID (uniquie 10-character string) in Apple dev account
 - export `IOS_UDID=<your-device-udid>` then run the script `run-tests-ios.sh`
-
+- considering that `port forwarding` is no longer available on iOS devices, to be able to use port forwarding it is necessary to follow the steps from https://alttester.com/docs/desktop/v.2.0.1/pages/known-issues.html#problem-with-reverse-port-forwarding-for-ios
 ## Running tests
 
 > **Note**: The tests are meant to be run on an iOS device.
 
-Create a folder `app` under project.
-The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCat.ipa.zip and needs to be included unzipped under app/ folder.
-To start the tests run:
+1. Install the [AltTesterDesktop](https://alttester.com/alttester/#pricing), then open it (you need to accept the Terms and Conditions if the AltTester is opened for the first time).
+2.  Create a folder `app` under project. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatiOS2_0_1.ipa.zip and needs to be included unzipped under app/ folder.
+3. To start the tests run:
 
-```
-$ ./run-tests-ios.sh
-```
+    ```
+    $ ./run-tests-ios.sh
+    ```
 
 This script will:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-AltTester-Driver==1.8.0
+AltTester-Driver==2.0.1
 pytest
 virtualenv
 Appium-Python-Client

--- a/tests/alt_test_case.py
+++ b/tests/alt_test_case.py
@@ -3,7 +3,6 @@ import time
 import os
 from appium import webdriver
 
-from alttester.portforwarding import AltPortForwarding
 from alttester import AltDriver
 
 
@@ -27,18 +26,7 @@ class AltTestCase(unittest.TestCase):
         cls.appium_driver = webdriver.Remote(
             'http://localhost:4723/wd/hub', cls.desired_caps)
         print("Appium driver started")
-        cls.setup_port_forwarding()
-        time.sleep(10)
         cls.altdriver = AltDriver(enable_logging=False)
-
-    @classmethod
-    def setup_port_forwarding(cls):
-        try:
-            AltPortForwarding.kill_all_iproxy_process()
-        except:
-            print("No iproxy forward was present")
-        AltPortForwarding.forward_ios()
-        print("Port forwarded (iOS).")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/alt_test_case.py
+++ b/tests/alt_test_case.py
@@ -26,6 +26,7 @@ class AltTestCase(unittest.TestCase):
         cls.appium_driver = webdriver.Remote(
             'http://localhost:4723/wd/hub', cls.desired_caps)
         print("Appium driver started")
+        time.sleep(10)
         cls.altdriver = AltDriver(enable_logging=False)
 
     @classmethod


### PR DESCRIPTION
What is done:
- Updated AltTester-Driver version
- Updated README.md with 2.0.1 info
- removed all port forwarding methods